### PR TITLE
NotClientWeapons.inc: анимации выстрела USP с глушителем и без были перепутаны

### DIFF
--- a/amxmodx/scripting/Cwapi/Core/CWeapons/NotClientWeapons.inc
+++ b/amxmodx/scripting/Cwapi/Core/CWeapons/NotClientWeapons.inc
@@ -897,10 +897,10 @@ static NotClientWeapons__GetDefaultAnimationData(
                         new iAnims;
                         if (IsWeaponSilenced(iWeapon)) {
                             iDefAnimsFlags |= BIT(eWeaponsDataAnimsFlags_Silenced);
-                            iAnims = random_num(9, 11);
+                            iAnims = random_num(1, 3);
                         } else {
                             iDefAnimsFlags |= BIT(eWeaponsDataAnimsFlags_Unsilenced);
-                            iAnims = random_num(1, 3);
+                            iAnims = random_num(9, 11);
                         }
 
                         return iAnims;


### PR DESCRIPTION
описание в заголовке